### PR TITLE
[feat]: Add TypeScript Type Checker as linter.

### DIFF
--- a/__phutil_library_map__.php
+++ b/__phutil_library_map__.php
@@ -11,10 +11,12 @@ phutil_register_library_map(array(
   'class' => array(
     'ESLintLinter' => 'src/lint/ESLintLinter.php',
     'JestTestEngine' => 'src/unit/JestTestEngine.php',
+    'TypeScriptTypeChecker' => 'src/lint/TypeScriptTypeChecker.php',
   ),
   'function' => array(),
   'xmap' => array(
     'ESLintLinter' => 'ArcanistExternalLinter',
     'JestTestEngine' => 'ArcanistUnitTestEngine',
+    'TypeScriptTypeChecker' => 'ArcanistExternalLinter',
   ),
 ));

--- a/src/lint/TypeScriptTypeChecker.php
+++ b/src/lint/TypeScriptTypeChecker.php
@@ -1,0 +1,105 @@
+<?php
+
+final class TypeScriptTypeChecker extends ArcanistExternalLinter {
+
+  public function getInfoName() {
+    return 'TypeScript type checker';
+  }
+
+  public function getInfoURI() {
+    return 'https://www.typescriptlang.org';
+  }
+
+  public function getInfoDescription() {
+    return 'Type check your TypeScript files';
+  }
+
+  public function getLinterName() {
+    return 'TypeScript type checker';
+  }
+
+  public function getLinterConfigurationName() {
+    return 'tstypechecker';
+  }
+
+  public function getDefaultBinary() {
+    list($npm_bin, $err) = execx('npm bin');
+    return Filesystem::resolvePath(
+      './tsc',
+      trim($npm_bin)
+    );
+  }
+
+  private function getParserBinary() {
+    list($npm_bin, $err) = execx('npm bin');
+    return Filesystem::resolvePath(
+      './tsc-output-parser',
+      trim($npm_bin)
+    );
+  }
+
+  public function getInstallInstructions() {
+    return pht('Add TypeScript to your project with `%s`.', 'yarn add -D typescript');
+  }
+
+  protected function getMandatoryFlags() {
+    $options = array();
+    $options[] = '--noEmit';
+    $options[] = '--target';
+    $options[] = 'esnext';
+    $options[] = '--module';
+    $options[] = 'commonjs';
+    $options[] = '--esModuleInterop';
+    $options[] = '--allowJs';
+    $options[] = '--skipLibCheck';
+    $options[] = '--noImplicitAny';
+    $options[] = '--strict';
+    $options[] = '--lib';
+    $options[] = 'ES6,DOM,ESNext,DOM.Iterable';
+    $options[] = '--jsx';
+    $options[] = 'react-native';
+    return $options;
+  }
+
+  protected function parseLinterOutput($path, $err, $stdout, $stderr) {
+    $lines = explode("\n", $stdout);
+    $filteredLines = array();
+    $messages = array();
+
+    foreach ($lines as &$line) {
+      if (preg_match("/^\W/", $line)) {
+        $index = count($filteredLines) - 1;
+        $filteredLines[$index] = $filteredLines[$index] . $line;
+      } else {
+        $filteredLines[] = $line;
+      }
+    }
+
+    foreach($filteredLines as &$line) {
+      preg_match("/^(\w.+)\((.+),(.+)\): (\w+) (\w+): (.+\.)$/", $line, $matches);
+
+      if ($matches) {
+        $dict = array(
+          'name' => $this->getLinterName(),
+          'path' => $matches[1],
+          'line' => $matches[2],
+          'char' => $matches[3],
+          'severity' => ArcanistLintSeverity::SEVERITY_WARNING,
+          'code' => $matches[5],
+          'description' => $matches[6],
+        );
+
+        $message = ArcanistLintMessage::newFromDictionary($dict);
+        $message->setBypassChangedLineFiltering(true);
+
+        if($dict['path'] != $path) {
+          $message->setSeverity(ArcanistLintSeverity::SEVERITY_DISABLED);
+        }
+
+        $messages[] = $message;
+      }
+    }
+
+    return $messages;
+  }
+}

--- a/src/lint/TypeScriptTypeChecker.php
+++ b/src/lint/TypeScriptTypeChecker.php
@@ -76,7 +76,7 @@ final class TypeScriptTypeChecker extends ArcanistExternalLinter {
     }
 
     foreach($filteredLines as &$line) {
-      preg_match("/^(\w.+)\((.+),(.+)\): (\w+) (\w+): (.+\.)$/", $line, $matches);
+      preg_match("/^(\w.+)\((.+),(.+)\): (\w+) (\w+): (.+)$/", $line, $matches);
 
       if ($matches) {
         $dict = array(

--- a/src/unit/JestTestEngine.php
+++ b/src/unit/JestTestEngine.php
@@ -19,6 +19,16 @@ final class JestTestEngine extends ArcanistUnitTestEngine {
 
     // TODO(duailibe, sherman) find a clean way to solve this
     $paths[] = "packages/codesharing/symlinksChecker.test.js";
+    foreach ($paths as $path) {
+      $absolute_web_path = str_replace(
+        '/rn/',
+        '/web/',
+        Filesystem::resolvePath($path, $this->project_root)
+      );
+      if (Filesystem::pathExists($absolute_web_path) && is_link($absolute_web_path)) {
+        $paths[] = $absolute_web_path;
+      }
+    }
 
     if (!$this->getRunAllTests()) {
       $options[] = csprintf('--findRelatedTests %Ls', $paths);

--- a/src/unit/JestTestEngine.php
+++ b/src/unit/JestTestEngine.php
@@ -17,6 +17,9 @@ final class JestTestEngine extends ArcanistUnitTestEngine {
     $paths = $this->getPaths();
     $options = array();
 
+    // TODO(duailibe, sherman) find a clean way to solve this
+    $paths[] = "packages/codesharing/symlinksChecker.test.js";
+
     if (!$this->getRunAllTests()) {
       $options[] = csprintf('--findRelatedTests %Ls', $paths);
     }


### PR DESCRIPTION
Summary: Add the TypeScript Type Checker as a linter to be run when the
`arc lint` is evocked.

As of right now, the severity of all errors are `Errors` will block devs
to open diffs, unless the errors are fixed, but due to the number of
errors related to our React Native Polyfills, it might be necessary to
fix them before deploying this patch to our arc-extensions.

Test Plan: Apply this patch to SGLearner's arc-extensions submodule,
modify any .ts or .tsx file and check if the file is processed by the
`arc lint` by both `ESLint` and `TypeScript Type Checker`.

Reviewers: rodriogoalmeida